### PR TITLE
cdm_createChildManagedObjectContext renamed to cdm_createBackgroundContext

### DIFF
--- a/CoreDataContextManager/Classes/CDMCoreDataContextManager.m
+++ b/CoreDataContextManager/Classes/CDMCoreDataContextManager.m
@@ -135,7 +135,7 @@
 }
 
 - (NSManagedObjectContext * _Nonnull)createBackgroundContext {
-    return [self.managedObjectContext cdm_createChildManagedObjectContext];
+    return [self.managedObjectContext cdm_createBackgroundContext];
 }
 
 #pragma mark - Properties

--- a/CoreDataContextManager/Classes/NSManagedObjectContext+CoreDataContextManager.h
+++ b/CoreDataContextManager/Classes/NSManagedObjectContext+CoreDataContextManager.h
@@ -9,10 +9,10 @@
 @interface NSManagedObjectContext (CoreDataContextManager)
 
 /*!
- @brief Create child managed object context for multithreading
+ @brief Create background thread context
  @return A NSManagedObjectContext object
  */
-- (NSManagedObjectContext * _Nonnull)cdm_createChildManagedObjectContext;
+- (NSManagedObjectContext * _Nonnull)cdm_createBackgroundContext;
 
 /*!
  @brief Save if NSManagedObjectContext has changed

--- a/CoreDataContextManager/Classes/NSManagedObjectContext+CoreDataContextManager.m
+++ b/CoreDataContextManager/Classes/NSManagedObjectContext+CoreDataContextManager.m
@@ -6,7 +6,7 @@
 @implementation NSManagedObjectContext (CoreDataContextManager)
 
 // Create background thread context
-- (NSManagedObjectContext * _Nonnull)cdm_createChildManagedObjectContext {
+- (NSManagedObjectContext * _Nonnull)cdm_createBackgroundContext {
     NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
     NSManagedObjectContext *parentContext = self.parentContext;
     if (!parentContext) {

--- a/Example/Tests/NSManagedObjectContext+CoreDataContextManagerTests.m
+++ b/Example/Tests/NSManagedObjectContext+CoreDataContextManagerTests.m
@@ -6,7 +6,7 @@
 
 SpecBegin(NSManagedObjectContext)
 
-describe(@"cdm_createChildManagedObjectContext", ^{
+describe(@"cdm_createBackgroundContext", ^{
     
     __block CDMCoreDataContextManager *manager;
     
@@ -16,7 +16,7 @@ describe(@"cdm_createChildManagedObjectContext", ^{
     
     it(@"create data from child thread", ^{
         waitUntil(^(DoneCallback done) {
-            NSManagedObjectContext *context = [manager createBackgroundContext];
+            NSManagedObjectContext *context = [manager.managedObjectContext cdm_createBackgroundContext];
             [context performBlock:^{
                 ExampleData *data = [NSEntityDescription insertNewObjectForEntityForName:@"ExampleData" inManagedObjectContext:context];
                 data.title = @"title";

--- a/README.md
+++ b/README.md
@@ -143,9 +143,14 @@ CoreDataContextManager add `NSManagedObjectContext (CoreDataContextManager)` cat
 The category contains the following methods.
 
 ```
-// Create child managed object context for multithreading,
-// same as [CoreDataContextManager createBackgroundContext]
-- (NSManagedObjectContext * _Nonnull)cdm_createChildManagedObjectContext;
+// Create managed object context for background thread.
+// It is same as [CoreDataContextManager createBackgroundContext] if
+// you call for CoreDataContextManager's managedObjectContext property,
+// otherwise returing NSManagedObjectContext is setup for background thread
+// and child of `this` NSManagedObjectContext but you should observe
+// NSManagedObjectContextDidSaveNotification and import updates from
+// the background thread by mergeChangesFromContextDidSaveNotification method.
+- (NSManagedObjectContext * _Nonnull)cdm_createBackgroundContext;
 
 // Save if NSManagedObjectContext has changed
 - (BOOL)cdm_saveChanges:(NSError * _Nullable * _Nullable)error;


### PR DESCRIPTION
Previously, CDMCoreDataContextManager has createBackgroundContext and
NSManagedObjectContext has cdm_createChildManagedObjectContext.
There are very simular functions with confusing names.
I unified to createBackgroundContext.